### PR TITLE
Draw colliderSize as a gizmo

### DIFF
--- a/Modified fragsurf/Movement/SurfCharacter.cs
+++ b/Modified fragsurf/Movement/SurfCharacter.cs
@@ -90,6 +90,12 @@ namespace Fragsurf.Movement {
 
         ///// Methods /////
 
+		private void OnDrawGizmos()
+		{
+			Gizmos.color = Color.red;
+			Gizmos.DrawWireCube( transform.position, colliderSize );
+		}
+		
         private void Awake () {
             
             _controller.playerTransform = playerRotationTransform;


### PR DESCRIPTION
This change causes the SurfCharacter's colliderSize to be drawn as a gizmo in the editor, which makes it much easier to place an object using this script into the world correctly